### PR TITLE
feat: 添加PlayerManager单例管理游戏参数

### DIFF
--- a/global/PlayerManager.cs
+++ b/global/PlayerManager.cs
@@ -1,0 +1,36 @@
+using System;
+using Godot;
+using GFramework.SourceGenerators.Abstractions.logging;
+using GFramework.SourceGenerators.Abstractions.rule;
+
+[ContextAware]
+[Log]
+public partial class PlayerManager : Node
+{
+    public static PlayerManager Instance { get; private set; }
+    
+    public float MaxFuel = 100.0f;//最大燃料
+    public float FuelConsumptionRate = 0.333f; // 每秒消耗的燃料量
+
+    public int WeaponCount = 2; // 武器数量
+    public int Damage = 5; // 子弹伤害
+    public float FireRate = 0.2f; // 射击间隔，单位秒
+
+    public float Speed = 300.0f; // 最大速度
+    public float Acceleration = 200.0f; // 加速度
+    public float BrakeForce = 150.0f; // 制动力
+    public float RotationSpeed = 5.0f; //转向角速度
+
+    public int OreGet = 10;	//矿物获取量
+    public int PickupRange = 1;//拾取范围大小倍率
+
+    public int MaxHeat = 100; //最大过热值
+    public int ColdDownRateNormal = 5; // 正常冷却速率：每秒降低 n点
+    public int ColdUpRateNormal = 2; // 正常加热速率：每次射击增加 n点
+    public int ColdDownRateOverHeat = 20; // 过热冷却速率：每秒降低 n点
+
+    public override void _Ready()
+    {
+        Instance = this;
+    }
+}

--- a/global/PlayerManager.cs.uid
+++ b/global/PlayerManager.cs.uid
@@ -1,0 +1,1 @@
+uid://c8813ghur10wv

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ config/save/setting_path="user://setting.json"
 
 GameEntryPoint="*res://global/game_entry_point.tscn"
 DevBindingManager="*res://global/dev_binding_manager.tscn"
+PlayerManager="*res://global/PlayerManager.cs"
 
 [display]
 

--- a/scenes/UI/cargo/Cargo.cs
+++ b/scenes/UI/cargo/Cargo.cs
@@ -21,7 +21,7 @@ private Label GemLabel => GetNode<Label>("%宝石1数量");
 	/// </summary>
 	public override void _Ready()
 	{
-		
+		OreGet = PlayerManager.Instance.OreGet;
 	}
 
     public override void _PhysicsProcess(double delta)

--- a/scenes/UI/fuel/Fuel.cs
+++ b/scenes/UI/fuel/Fuel.cs
@@ -19,7 +19,7 @@ public partial class Fuel :HBoxContainer,IController
 	public override void _Ready()
 	{
 		UpdateFuelUI(); // 使用SpaceShip的当前Fuel值更新UI
-		ProgressBar.MaxValue = SpaceShip.MaxFuel;
+		ProgressBar.MaxValue = PlayerManager.Instance.MaxFuel;
 	}
 
 	public override void _Process(double delta)

--- a/scenes/loot/Loot.cs
+++ b/scenes/loot/Loot.cs
@@ -14,14 +14,7 @@ public partial class Loot : CharacterBody2D
 
     public override void _Ready()
     {
-        if (Cargo != null)
-		{
-			GD.Print("成功获取Cargo节点");
-		}
-		else
-		{
-			GD.PrintErr("未能获取Cargo节点");
-		}
+
     }
 
 

--- a/scenes/loot/loot.tscn
+++ b/scenes/loot/loot.tscn
@@ -27,13 +27,13 @@ animations = [{
 
 [node name="Loot" type="CharacterBody2D"]
 collision_layer = 32
-collision_mask = 17
+collision_mask = 16
 script = ExtResource("1_01umk")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
 sprite_frames = SubResource("SpriteFrames_6mdjo")
-animation = &"散矿"
+animation = &"宝石1"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_dyds6")

--- a/scenes/space_rock/SpaceRock.cs
+++ b/scenes/space_rock/SpaceRock.cs
@@ -125,7 +125,7 @@ public partial class SpaceRock : RigidBody2D
 			// 减少血量
 			if (AsteroidData != null)
 			{
-				AsteroidData.Health -= 5; // 每发子弹造成5点伤害
+				AsteroidData.Health -= PlayerManager.Instance.Damage; // 每发子弹造成 n点伤害
 
 				if (AsteroidData.Health <= 0 && !_hasDroppedLoot) // 确保只掉落一次
 				{

--- a/scenes/space_ship/Gun/Gun.cs
+++ b/scenes/space_ship/Gun/Gun.cs
@@ -14,10 +14,10 @@ public partial class Gun : Sprite2D, IController
 
 	// 过热机制相关变量
 	private float _heat = 0f; // 当前过热值
-	private const float MAX_HEAT = 100f; // 最大过热值
+	private float MAX_HEAT = 100; // 最大过热值
 	private bool _isOverheated = false; // 是否过热
-	private const float COOL_DOWN_RATE_NORMAL = 5f; // 正常冷却速率：每秒降低5点
-	private const float COOL_DOWN_RATE_OVERHEAT = 20f; // 过热冷却速率：每秒降低20点
+	private float COOL_DOWN_RATE_NORMAL = 5; // 正常冷却速率：每秒降低5点
+	private float COOL_DOWN_RATE_OVERHEAT = 20; // 过热冷却速率：每秒降低20点
 
 	// 公共属性，供UI访问
 	public float Heat => _heat;
@@ -30,6 +30,12 @@ public partial class Gun : Sprite2D, IController
 	/// </summary>
 	public override void _Ready()
 	{
+		//初始化全局变量
+		FireRate = PlayerManager.Instance.FireRate; // 射击间隔，单位秒
+		MAX_HEAT = PlayerManager.Instance.MaxHeat; // 最大过热值
+		COOL_DOWN_RATE_NORMAL = PlayerManager.Instance.ColdDownRateNormal; // 正常冷却速率：每秒降低5点
+		COOL_DOWN_RATE_OVERHEAT = PlayerManager.Instance.ColdDownRateOverHeat; // 过热冷却速率：每秒降低20点
+
 		_bulletScene = GD.Load<PackedScene>("res://scenes/space_ship/Bullet/Bullet.tscn");
 	}
 
@@ -98,7 +104,7 @@ public partial class Gun : Sprite2D, IController
 		bullet.Velocity = initialDirection * bullet.BulletSpeed;
 
 		// 增加过热值
-		_heat += 2f;
+		_heat += PlayerManager.Instance.ColdUpRateNormal;
 
 		// 检查是否过热
 		if (_heat >= MAX_HEAT)

--- a/scenes/space_ship/SpaceShip.cs
+++ b/scenes/space_ship/SpaceShip.cs
@@ -7,21 +7,20 @@ using GFramework.SourceGenerators.Abstractions.rule;
 [Log]
 public partial class SpaceShip :CharacterBody2D,IController
 {
-    // 旋转速度
-    [Export] public float RotationSpeed = 5.0f;
+    [Export] public float RotationSpeed = 5.0f; //转向角速度
     
     // 移动相关参数
-    [Export] public float Acceleration = 400.0f;      // 推力加速度
-    [Export] public float MaxSpeed = 600.0f;          // 最大速度
-    [Export] public float BrakeForce = 300.0f;          // 制动力
+    [Export] public float Acceleration = 200;      // 推力加速度
+    [Export] public float MaxSpeed = 300;          // 最大速度
+    [Export] public float BrakeForce = 150;          // 制动力
     private bool isMoving = false;                    // 是否正在移动
     
 
     //飞船属性
-    [Export] public float Fuel  = 100.0f;
     [Export] public float MaxFuel = 100.0f;
+    [Export] public float Fuel  = 100.0f;
     [Export] public float FuelConsumptionRate = 0.333f; // 每秒消耗的燃料量 (100燃料/300秒 = 0.333)
-    
+
     public Gun Gun => GetNode<Gun>("%Gun");
     private Area2D LootArea => GetNode<Area2D>("%LootArea");
 	
@@ -31,6 +30,19 @@ public partial class SpaceShip :CharacterBody2D,IController
 	/// </summary>
 	public override void _Ready()
 	{
+        //初始化全局变量
+        RotationSpeed = PlayerManager.Instance.RotationSpeed; //转向角速度
+        Acceleration = PlayerManager.Instance.Acceleration;      // 推力加速度
+        MaxSpeed = PlayerManager.Instance.Speed;          // 最大速度
+        BrakeForce = PlayerManager.Instance.BrakeForce;          // 制动力
+        MaxFuel = PlayerManager.Instance.MaxFuel;
+        Fuel = PlayerManager.Instance.MaxFuel;
+        FuelConsumptionRate = PlayerManager.Instance.FuelConsumptionRate; // 每秒消耗的燃料量 (100燃料/300秒 = 0.333)
+
+        LootArea.Scale = PlayerManager.Instance.PickupRange * Vector2.One;
+
+
+
 		LootArea.BodyEntered += OnLootEntered;
 	}
 

--- a/scenes/space_ship/space_ship.tscn
+++ b/scenes/space_ship/space_ship.tscn
@@ -27,7 +27,7 @@ shader_parameter/outline_width2 = 2.0
 radius = 31.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_w5ed5"]
-radius = 237.32047
+radius = 99.00505
 
 [node name="SpaceShip" type="CharacterBody2D"]
 script = ExtResource("1_mnm42")

--- a/scenes/space_station/space_station.tscn
+++ b/scenes/space_station/space_station.tscn
@@ -6,8 +6,15 @@
 [node name="SpaceStation" type="Node2D"]
 script = ExtResource("1_3yv4l")
 
-[node name="Depart" type="Button" parent="."]
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="Depart" type="Button" parent="Control"]
 unique_name_in_owner = true
+layout_mode = 0
 offset_left = 1743.0
 offset_top = 934.0
 offset_right = 1863.0


### PR DESCRIPTION
添加PlayerManager.cs作为全局参数管理器，统一管理系统配置参数。

- 在project.godot中注册PlayerManager单例
- 替换各场景中的硬编码数值为PlayerManager属性
- 更新飞船、枪械等组件使用全局参数
- 调整碰撞半径和拾取范围配置
- 移除调试打印代码
- 修改空间站界面布局结构
#5 