### PR TITLE
feat(gameplay): 实现玩家矿石收集与存档系统

### DIFF
--- a/global/PlayerManager.cs
+++ b/global/PlayerManager.cs
@@ -2,6 +2,8 @@ using System;
 using Godot;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
+using GFramework.Core.extensions;
+using CosmicMiningCompany.scripts.data.interfaces;
 
 [ContextAware]
 [Log]
@@ -9,7 +11,7 @@ public partial class PlayerManager : Node
 {
     public static PlayerManager Instance { get; private set; }
     
-    public float MaxFuel = 100.0f;//最大燃料
+    public float MaxFuel = 10.0f;//最大燃料
     public float FuelConsumptionRate = 0.333f; // 每秒消耗的燃料量
 
     public int WeaponCount = 2; // 武器数量
@@ -24,13 +26,54 @@ public partial class PlayerManager : Node
     public int OreGet = 10;	//矿物获取量
     public int PickupRange = 1;//拾取范围大小倍率
 
+    //任务中获得的矿石数量
+    public int OreCount = 0; //任务获得散矿数量
+    public int GemCount = 0; //任务获得宝石数量
+
+    //存档的矿物总量
+    public int TotalOreCount = 0; //总矿物数量
+    public int TotalGemCount = 0; //总宝石数量
+
     public int MaxHeat = 100; //最大过热值
     public int ColdDownRateNormal = 5; // 正常冷却速率：每秒降低 n点
     public int ColdUpRateNormal = 2; // 正常加热速率：每次射击增加 n点
     public int ColdDownRateOverHeat = 20; // 过热冷却速率：每秒降低 n点
 
+    private ISaveStorageUtility _saveStorageUtility = null!;
+
     public override void _Ready()
     {
         Instance = this;
+        
+        // 获取存档工具依赖
+        _saveStorageUtility = this.GetUtility<ISaveStorageUtility>()!;
+        
+        // 从存档初始化总矿石量
+        InitializeFromSave();
+    }
+
+    /// <summary>
+    /// 从存档初始化总矿石量
+    /// </summary>
+    private void InitializeFromSave()
+    {
+        if (_saveStorageUtility != null)
+        {
+            TotalOreCount = _saveStorageUtility.GetItemCount("Ore");
+            TotalGemCount = _saveStorageUtility.GetItemCount("Gem");
+            GD.Print($"从存档初始化矿石量: Ore={TotalOreCount}, Gem={TotalGemCount}");
+        }
+    }
+
+    /// <summary>
+    /// 更新总矿石量（当任务矿石添加到存档后调用）
+    /// </summary>
+    public void UpdateTotalOreFromSave()
+    {
+        if (_saveStorageUtility != null)
+        {
+            TotalOreCount = _saveStorageUtility.GetItemCount("Ore");
+            TotalGemCount = _saveStorageUtility.GetItemCount("Gem");
+        }
     }
 }

--- a/scenes/UI/cargo/Cargo.cs
+++ b/scenes/UI/cargo/Cargo.cs
@@ -8,8 +8,6 @@ using GFramework.SourceGenerators.Abstractions.rule;
 [Log]
 public partial class Cargo :VBoxContainer,IController
 {
-	public int OreCount = 0; //散矿
-	public int GemCount = 0; //宝石
 	public int OreGet = 10;	//矿物获取量
 
 private Label OreLabel => GetNode<Label>("%散矿数量");
@@ -22,9 +20,12 @@ private Label GemLabel => GetNode<Label>("%宝石1数量");
 	public override void _Ready()
 	{
 		OreGet = PlayerManager.Instance.OreGet;
+		//重置任务矿石数量
+		PlayerManager.Instance.OreCount = 0;
+		PlayerManager.Instance.GemCount = 0;
 	}
 
-    public override void _PhysicsProcess(double delta)
+    public override void _Process(double delta)
     {
         //更新UI
         UpdateOreUI();
@@ -32,8 +33,8 @@ private Label GemLabel => GetNode<Label>("%宝石1数量");
 
 	public void UpdateOreUI()
 	{
-        OreLabel.Text = OreCount.ToString();
-        GemLabel.Text = GemCount.ToString();
+        OreLabel.Text = PlayerManager.Instance.OreCount.ToString();
+        GemLabel.Text = PlayerManager.Instance.GemCount.ToString();
 	}
 
 
@@ -47,12 +48,14 @@ private Label GemLabel => GetNode<Label>("%宝石1数量");
 		if (OreName == "散矿")
 		{
 			GD.Print("散矿+1");
-			OreCount += OreGet;
+			PlayerManager.Instance.OreCount += OreGet;
+
 		}
 		if (OreName == "宝石1")
 		{
 			GD.Print("宝石1 +1");
-			GemCount += OreGet;
+			PlayerManager.Instance.GemCount += OreGet;
+
 		}
 		
 	}

--- a/scenes/UI/storage/Storage.cs
+++ b/scenes/UI/storage/Storage.cs
@@ -1,0 +1,24 @@
+using Godot;
+using GFramework.Core.Abstractions.controller;
+using GFramework.Core.extensions;
+using GFramework.SourceGenerators.Abstractions.logging;
+using GFramework.SourceGenerators.Abstractions.rule;
+using CosmicMiningCompany.scripts.data.interfaces;
+
+
+[ContextAware]
+[Log]
+public partial class Storage : VBoxContainer, IController
+{
+	private Label OreLabel => GetNode<Label>("%散矿数量");
+	private Label GemLabel => GetNode<Label>("%宝石1数量");
+
+	public override void _Process(double delta)
+	{
+		if (PlayerManager.Instance != null)
+		{
+			OreLabel.Text = PlayerManager.Instance.TotalOreCount.ToString();
+			GemLabel.Text = PlayerManager.Instance.TotalGemCount.ToString();
+		}
+	}
+}

--- a/scenes/UI/storage/Storage.cs.uid
+++ b/scenes/UI/storage/Storage.cs.uid
@@ -1,0 +1,1 @@
+uid://dad4wg6f3vovn

--- a/scenes/UI/storage/storage.tscn
+++ b/scenes/UI/storage/storage.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=4 format=3 uid="uid://bka7jj2s5xkgf"]
+
+[ext_resource type="Script" uid="uid://dad4wg6f3vovn" path="res://scenes/UI/storage/Storage.cs" id="1_x8ul4"]
+[ext_resource type="Texture2D" uid="uid://cckcub1a5r2xr" path="res://assets/art/散矿.png" id="2_48qxi"]
+[ext_resource type="Texture2D" uid="uid://cc0kyy84m3qcu" path="res://assets/art/宝石.png" id="3_avfx2"]
+
+[node name="Storage" type="VBoxContainer"]
+script = ExtResource("1_x8ul4")
+
+[node name="散矿" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="TextureRect" type="TextureRect" parent="散矿"]
+layout_mode = 2
+texture = ExtResource("2_48qxi")
+
+[node name="散矿数量" type="Label" parent="散矿"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "10000"
+
+[node name="宝石1" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="TextureRect" type="TextureRect" parent="宝石1"]
+layout_mode = 2
+texture = ExtResource("3_avfx2")
+
+[node name="宝石1数量" type="Label" parent="宝石1"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "10000"

--- a/scenes/main_menu/MainMenu.cs
+++ b/scenes/main_menu/MainMenu.cs
@@ -1,34 +1,48 @@
 using GFramework.Core.Abstractions.controller;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
+using CosmicMiningCompany.scripts.data.interfaces;
 using Godot;
+using GFramework.Core.extensions;
 
 namespace CosmicMiningCompany.scenes.main_menu;
 
 [ContextAware]
 [Log]
-public partial class MainMenu :Control,IController
+public partial class MainMenu : Control, IController
 {
+	private ISaveStorageUtility _saveStorageUtility = null!;
+	
 	/// <summary>
 	/// 节点准备就绪时的回调方法
 	/// 在节点添加到场景树后调用
 	/// </summary>
 	public override void _Ready()
 	{
+		// 获取存档工具依赖
+		_saveStorageUtility = this.GetUtility<ISaveStorageUtility>()!;
+
 		GetNode<Button>("%NewGame").Pressed += () =>
 		{
 			GD.Print("新游戏");
 			_log.Debug("新游戏");
+			
+			// 创建新存档
+			_saveStorageUtility.NewGame();
+			
 			GetTree().ChangeSceneToFile("res://scenes/space_station/space_station.tscn");
 		};
-
 
 		GetNode<Button>("%Continue").Pressed += () =>
 		{
 			GD.Print("继续游戏");
 			_log.Debug("继续游戏");
+			
+			// 加载现有存档
+			_saveStorageUtility.Load();
+			
+			GetTree().ChangeSceneToFile("res://scenes/space_station/space_station.tscn");
 		};
-
 
 		GetNode<Button>("%Option").Pressed += () =>
 		{
@@ -38,16 +52,13 @@ public partial class MainMenu :Control,IController
 			var optionScene = GD.Load<PackedScene>("res://scenes/Options/Options.tscn").Instantiate() as Control;
 			// 将其添加到当前场景中
 			AddChild(optionScene);
-
 		};
-
 
 		GetNode<Button>("%Credits").Pressed += () =>
 		{
 			GD.Print("制作人员名单");
 			_log.Debug("制作人员名单");
 		};
-
 
 		GetNode<Button>("%Exit").Pressed += () =>
 		{

--- a/scenes/space_ship/SpaceShip.cs
+++ b/scenes/space_ship/SpaceShip.cs
@@ -218,10 +218,12 @@ public partial class SpaceShip :CharacterBody2D,IController
         if (Fuel > 0)
         {
             Fuel -= FuelConsumptionRate * delta;
-            if (Fuel < 0)
+            if (Fuel <= 0)
             {
                 Fuel = 0;
                 GD.Print("燃料耗尽！");
+                //回到空间站
+                GetTree().ChangeSceneToFile("res://scenes/space_station/space_station.tscn");
             }
         }
     }

--- a/scenes/space_station/SpaceStation.cs
+++ b/scenes/space_station/SpaceStation.cs
@@ -1,26 +1,70 @@
-using Godot;
+using CosmicMiningCompany.scripts.data.interfaces;
 using GFramework.Core.Abstractions.controller;
+using GFramework.Core.extensions;
 using GFramework.SourceGenerators.Abstractions.logging;
 using GFramework.SourceGenerators.Abstractions.rule;
+using Godot;
 
 
 [ContextAware]
 [Log]
 public partial class SpaceStation :Node2D,IController
 {
+	private ISaveStorageUtility _saveStorageUtility = null!;
 	/// <summary>
 	/// 节点准备就绪时的回调方法
 	/// 在节点添加到场景树后调用
 	/// </summary>
 	public override void _Ready()
-	{
-		GetNode<Button>("%Depart").Pressed += () =>
-		{
-			GD.Print("离港");
-			_log.Debug("离港");
-			GetTree().ChangeSceneToFile("res://scenes/space/space.tscn");
-		};
-	}
+    {
+        _saveStorageUtility = this.GetUtility<ISaveStorageUtility>()!;
+
+        DataLoad();
+
+        GetNode<Button>("%Depart").Pressed += () =>
+        {
+            GD.Print("离港");
+            _log.Debug("离港");
+            GetTree().ChangeSceneToFile("res://scenes/space/space.tscn");
+        };
+    }
+
+	/// <summary>
+	/// 初始化存档数据
+	/// </summary>
+    private void DataLoad()
+    {
+        // 加载存档
+        _saveStorageUtility.Load();
+
+        // 获取PlayerManager中的任务矿石数量
+        var playerManager = PlayerManager.Instance;
+        if (playerManager != null)
+        {
+            // 添加散矿到存档
+            if (playerManager.OreCount > 0)
+            {
+                _saveStorageUtility.AddItem("Ore", playerManager.OreCount);
+                _log.Debug($"添加散矿: {playerManager.OreCount}");
+            }
+
+            // 添加宝石到存档
+            if (playerManager.GemCount > 0)
+            {
+                _saveStorageUtility.AddItem("Gem", playerManager.GemCount);
+                _log.Debug($"添加宝石: {playerManager.GemCount}");
+            }
+
+            // 保存存档
+            _saveStorageUtility.Save();
+
+            // 更新PlayerManager中的总矿石量
+            playerManager.UpdateTotalOreFromSave();
+
+            // 重置任务矿石数量
+            playerManager.OreCount = 0;
+            playerManager.GemCount = 0;
+        }
+    }
+
 }
-
-

--- a/scenes/space_station/space_station.tscn
+++ b/scenes/space_station/space_station.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://b81p3y0rlcajm"]
+[gd_scene load_steps=4 format=3 uid="uid://b81p3y0rlcajm"]
 
 [ext_resource type="Script" uid="uid://crouxsxjt42mk" path="res://scenes/space_station/SpaceStation.cs" id="1_3yv4l"]
 [ext_resource type="Theme" uid="uid://cfadp5dxx3ld1" path="res://resources/theme.tres" id="2_pa1ah"]
+[ext_resource type="PackedScene" uid="uid://bka7jj2s5xkgf" path="res://scenes/UI/storage/storage.tscn" id="3_x2jrh"]
 
 [node name="SpaceStation" type="Node2D"]
 script = ExtResource("1_3yv4l")
@@ -21,3 +22,9 @@ offset_right = 1863.0
 offset_bottom = 982.0
 theme = ExtResource("2_pa1ah")
 text = "离港"
+
+[node name="Storage" parent="Control" instance=ExtResource("3_x2jrh")]
+layout_mode = 0
+offset_top = 338.0
+offset_right = 148.0
+offset_bottom = 470.0

--- a/scripts/data/GameSaveData.cs
+++ b/scripts/data/GameSaveData.cs
@@ -34,4 +34,3 @@ public class GameSaveData
     [JsonIgnore]
     public bool RuntimeDirty { get; set; }
 }
-


### PR DESCRIPTION
- 添加了玩家管理器中的矿石计数功能，包括任务获得的矿石和总存档矿石
- 集成了存档存储工具接口用于持久化矿石数据
- 实现了从存档初始化矿石数量的功能
- 更新货物界面显示玩家管理器中的实时矿石数量
- 在空间站场景中实现矿石数据的存档加载和保存逻辑
- 主菜单中集成新的游戏和继续游戏存档功能
- 飞船燃料耗尽时自动返回空间站场景
- 调整最大燃料值从100到10
- 在空间站界面添加存储UI组件
#20 