### PR TITLE
feat(loot): 添加碰撞检测控制逻辑并优化场景结构

### DIFF
--- a/scenes/loot/Loot.cs
+++ b/scenes/loot/Loot.cs
@@ -20,6 +20,7 @@ public partial class Loot : CharacterBody2D, IPoolableNode, IController
 
 	private SpaceShip SpaceShip => GetTree().Root.GetNode<SpaceShip>("Space/SpaceShip");
 	private AnimatedSprite2D AnimatedSprite2D => GetNode<AnimatedSprite2D>("%AnimatedSprite2D");
+	private CollisionShape2D CollisionShape => GetNode<CollisionShape2D>("%CollisionShape2D");
 
 	private Cargo Cargo => GetTree().Root.GetNode<Cargo>("Space/UI/Cargo");
 
@@ -81,6 +82,25 @@ public partial class Loot : CharacterBody2D, IPoolableNode, IController
 		Visible = true;
 		SetProcess(true);
 		SetPhysicsProcess(true);
+		
+		// 暂时禁用碰撞检测，避免刚生成时立即触发检测区域事件
+		if (CollisionShape != null)
+		{
+			CollisionShape.Disabled = true;
+			// 延迟一帧后重新启用碰撞检测
+			CallDeferred(nameof(EnableCollision));
+		}
+	}
+	
+	/// <summary>
+	/// 启用碰撞检测（延迟调用）
+	/// </summary>
+	private void EnableCollision()
+	{
+		if (CollisionShape != null)
+		{
+			CollisionShape.Disabled = false;
+		}
 	}
 
 	/// <summary>
@@ -89,6 +109,11 @@ public partial class Loot : CharacterBody2D, IPoolableNode, IController
 	public void OnRelease()
 	{
 		IsCollected = false;
+		// 确保碰撞检测被禁用，避免在池中时仍然触发事件
+		if (CollisionShape != null)
+		{
+			CollisionShape.Disabled = true;
+		}
 	}
 
 	/// <summary>

--- a/scenes/loot/loot.tscn
+++ b/scenes/loot/loot.tscn
@@ -36,4 +36,5 @@ sprite_frames = SubResource("SpriteFrames_6mdjo")
 animation = &"宝石1"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+unique_name_in_owner = true
 shape = SubResource("CircleShape2D_dyds6")

--- a/scenes/space/space.tscn
+++ b/scenes/space/space.tscn
@@ -16,12 +16,13 @@ z_index = -10
 [node name="AsteroidRoot" type="Node2D" parent="."]
 unique_name_in_owner = true
 
-[node name="Camera2D" type="Camera2D" parent="."]
-unique_name_in_owner = true
-
 [node name="SpaceShip" parent="." instance=ExtResource("1_t2gi8")]
 unique_name_in_owner = true
 position = Vector2(961, 542)
+
+[node name="Camera2D" type="Camera2D" parent="SpaceShip"]
+unique_name_in_owner = true
+position = Vector2(-3, 1)
 
 [node name="UI" type="CanvasLayer" parent="."]
 


### PR DESCRIPTION
- 在Loot类中添加CollisionShape2D引用，用于控制碰撞检测
- 实现延迟启用碰撞检测机制，避免生成时立即触发区域事件
- 在对象释放时确保碰撞检测被禁用，防止池中对象触发事件
- 将相机节点从Space根节点移动到SpaceShip节点下，优化场景层级结构
- 为CollisionShape2D节点添加唯一名称标识
#67 没卵用，md