### PR TITLE
refactor(loot): 移除矿石免疫机制并优化拾取检测逻辑

### DIFF
--- a/scenes/space_ship/SpaceShip.cs
+++ b/scenes/space_ship/SpaceShip.cs
@@ -228,12 +228,24 @@ public partial class SpaceShip :CharacterBody2D,IController
 		}
 	}
 
-	public void OnLootEntered(Node body)
+	public void OnLootEntered(Node2D body)
 	{
 		if (body is Loot loot)
 		{
 			GD.Print("检测到矿石");
-			loot.HasCollect();
+			// 获取飞船的检测区域
+			// 获取检测区域的碰撞形状
+			var collisionShape = LootArea.GetNodeOrNull<CollisionShape2D>("%LootCollisionShape2D");
+			
+			// 计算检测区域的全局位置和大小
+			var areaGlobalPos = LootArea.GlobalPosition;
+			var shape = collisionShape.Shape as CircleShape2D;
+			
+			// 计算检测半径（考虑缩放）
+			float detectionRadius = shape.Radius * LootArea.Scale.X;
+
+				loot.HasCollect(detectionRadius);
+			
 		}
 	}
 }

--- a/scenes/space_ship/space_ship.tscn
+++ b/scenes/space_ship/space_ship.tscn
@@ -98,5 +98,6 @@ unique_name_in_owner = true
 collision_layer = 16
 collision_mask = 32
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="LootArea"]
+[node name="LootCollisionShape2D" type="CollisionShape2D" parent="LootArea"]
+unique_name_in_owner = true
 shape = SubResource("CircleShape2D_w5ed5")


### PR DESCRIPTION
移除了矿石的免疫期相关代码，包括免疫帧计数器和碰撞检测禁用逻辑。
修改了HasCollect方法以接收检测半径参数，直接通过距离判断来决定是否拾取矿石，
避免了免疫期机制的复杂性。

fix(space_ship): 改进拾取区域碰撞检测实现

修改OnLootEntered方法参数类型为Node2D，添加了对检测区域碰撞形状的
获取和计算逻辑，动态计算检测半径并传递给矿石的HasCollect方法。

refactor(space_ship): 为拾取碰撞形状添加唯一名称标识

修改场景文件中LootArea下的CollisionShape2D节点名为LootCollisionShape2D 并添加unique_name_in_owner属性，便于代码中通过名称查找节点。
#10 