### PR TITLE
feat(game-mechanics): 调整燃料系统并实现游戏结束界面

### DIFF
--- a/global/PlayerManager.cs
+++ b/global/PlayerManager.cs
@@ -11,7 +11,7 @@ public partial class PlayerManager : Node
 {
     public static PlayerManager Instance { get; private set; }
     
-    public float MaxFuel = 100.0f;//最大燃料
+    public float MaxFuel = 10.0f;//最大燃料
     public float FuelConsumptionRate = 0.333f; // 每秒消耗的燃料量
 
     public int WeaponCount = 2; // 武器数量

--- a/scenes/UI/cargo/Cargo_2.cs
+++ b/scenes/UI/cargo/Cargo_2.cs
@@ -1,0 +1,76 @@
+using Godot;
+using GFramework.Core.Abstractions.controller;
+using GFramework.SourceGenerators.Abstractions.logging;
+using GFramework.SourceGenerators.Abstractions.rule;
+
+
+[ContextAware]
+[Log]
+public partial class Cargo_2 :VBoxContainer,IController
+{
+	private Label OreLabel => GetNode<Label>("%散矿数量");
+	private Label GemLabel => GetNode<Label>("%宝石1数量");
+	/// <summary>
+	/// 节点准备就绪时的回调方法
+	/// 在节点添加到场景树后调用
+	/// </summary>
+public override void _Ready()
+	{
+		// 开始动画，从0逐渐增加到PlayerManager中的count值
+		StartCountAnimation();
+	}
+	
+	/// <summary>
+	/// 开始计数动画，从0逐渐增加到目标值
+	/// </summary>
+	private void StartCountAnimation()
+	{
+		// 保存当前目标值作为动画终点
+		int targetOreCount = PlayerManager.Instance.OreCount;
+		int targetGemCount = PlayerManager.Instance.GemCount;
+		
+		// 重置显示为0开始动画
+		OreLabel.Text = "0";
+		GemLabel.Text = "0";
+		
+		// 创建动画，从0到目标值，用时2秒
+		var tween = CreateTween();
+		tween.SetParallel(true); // 并行处理两个标签的动画
+		
+		// 动画 OreCount 从 0 到目标值
+		tween.TweenMethod(
+			new Callable(this, nameof(SetAnimatedOreCount)),
+			0,
+			targetOreCount,
+			2.0f // 2秒完成动画
+		).SetTrans(Tween.TransitionType.Linear);
+		
+		// 动画 GemCount 从 0 到目标值
+		tween.TweenMethod(
+			new Callable(this, nameof(SetAnimatedGemCount)),
+			0,
+			targetGemCount,
+			2.0f // 2秒完成动画
+		).SetTrans(Tween.TransitionType.Linear);
+	}
+	
+	/// <summary>
+	/// 设置动画中的 OreCount 值
+	/// </summary>
+	/// <param name="value">当前动画值</param>
+	private void SetAnimatedOreCount(float value)
+	{
+		OreLabel.Text = ((int)value).ToString();
+	}
+	
+	/// <summary>
+	/// 设置动画中的 GemCount 值
+	/// </summary>
+	/// <param name="value">当前动画值</param>
+	private void SetAnimatedGemCount(float value)
+	{
+		GemLabel.Text = ((int)value).ToString();
+	}
+}
+
+

--- a/scenes/UI/cargo/Cargo_2.cs.uid
+++ b/scenes/UI/cargo/Cargo_2.cs.uid
@@ -1,0 +1,1 @@
+uid://mhfkay63huad

--- a/scenes/UI/game_over/GameOver.cs
+++ b/scenes/UI/game_over/GameOver.cs
@@ -1,0 +1,32 @@
+using Godot;
+using GFramework.Core.Abstractions.controller;
+using GFramework.SourceGenerators.Abstractions.logging;
+using GFramework.SourceGenerators.Abstractions.rule;
+
+
+[ContextAware]
+[Log]
+public partial class GameOver :Control,IController
+{
+	/// <summary>
+	/// 节点准备就绪时的回调方法
+	/// 在节点添加到场景树后调用
+	/// </summary>
+	public override void _Ready()
+	{
+		GetNode<Button>("%Button").Pressed += () =>
+		{
+			GD.Print("返回空间站");
+			_log.Debug("返回空间站");
+
+			QueueFree();
+			GetTree().Paused = false;
+			
+			GetTree().ChangeSceneToFile("res://scenes/space_station/space_station.tscn");
+		};
+	}
+
+
+}
+
+

--- a/scenes/UI/game_over/GameOver.cs.uid
+++ b/scenes/UI/game_over/GameOver.cs.uid
@@ -1,0 +1,1 @@
+uid://chk6ibgkxoewi

--- a/scenes/UI/game_over/game_over.tscn
+++ b/scenes/UI/game_over/game_over.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=4 format=3 uid="uid://t0hrgaee2kpu"]
+
+[ext_resource type="Script" uid="uid://chk6ibgkxoewi" path="res://scenes/UI/game_over/GameOver.cs" id="1_apbb1"]
+[ext_resource type="PackedScene" uid="uid://wvy8y4twx6s2" path="res://scenes/UI/cargo/cargo.tscn" id="1_y5qob"]
+[ext_resource type="Script" uid="uid://mhfkay63huad" path="res://scenes/UI/cargo/Cargo_2.cs" id="2_m5xgc"]
+
+[node name="GameOver" type="Control"]
+process_mode = 3
+z_index = 1
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_apbb1")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="MarginContainer" type="CenterContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+layout_mode = 2
+theme_override_constants/separation = 32
+alignment = 1
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 96
+text = "任务结束"
+horizontal_alignment = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="Cargo" parent="Panel/MarginContainer/VBoxContainer/HBoxContainer" instance=ExtResource("1_y5qob")]
+layout_mode = 2
+script = ExtResource("2_m5xgc")
+
+[node name="Button" type="Button" parent="Panel/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "返回空间站"

--- a/scenes/space/space.tscn
+++ b/scenes/space/space.tscn
@@ -25,6 +25,7 @@ unique_name_in_owner = true
 position = Vector2(-3, 1)
 
 [node name="UI" type="CanvasLayer" parent="."]
+unique_name_in_owner = true
 
 [node name="Fuel" parent="UI" instance=ExtResource("2_ugvpa")]
 

--- a/scenes/space_ship/SpaceShip.cs
+++ b/scenes/space_ship/SpaceShip.cs
@@ -222,8 +222,14 @@ public partial class SpaceShip :CharacterBody2D,IController
 			{
 				Fuel = 0;
 				GD.Print("燃料耗尽！");
-				//回到空间站
-				GetTree().ChangeSceneToFile("res://scenes/space_station/space_station.tscn");
+				//实例化结算界面
+				PackedScene gameOverScene = ResourceLoader.Load<PackedScene>("res://scenes/UI/game_over/game_over.tscn");
+				Node gameOverInstance = gameOverScene.Instantiate();
+				
+				// 添加到Camera2D下
+				GetNode<CanvasLayer>("%UI").AddChild(gameOverInstance);
+				GetTree().Paused = true;
+
 			}
 		}
 	}

--- a/scenes/space_station/SpaceStation.cs
+++ b/scenes/space_station/SpaceStation.cs
@@ -20,6 +20,8 @@ public partial class SpaceStation :Control,IController
 	/// </summary>
 	public override void _Ready()
 	{
+		GetTree().Paused = false;
+		
 		_saveStorageUtility = this.GetUtility<ISaveStorageUtility>()!;
 		
 		// 获取TextTyper节点


### PR DESCRIPTION
- 将玩家管理器中的最大燃料从100调整为10，使游戏更具挑战性
- 在太空场景中为UI节点添加唯一名称标识
- 实现燃料耗尽时的游戏结束流程，替换原来的空间站返回机制
- 创建结算界面并在燃料耗尽时显示，暂停游戏树
- 在空间站场景中重置游戏暂停状态以确保正常游戏流程
#54 