### PR TITLE
chore(workflow): 更新发布工作流中的构件名称

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         run: zip -r build/${{ env.EXPORT_NAME }}-linux.zip build/linux
       - uses: actions/upload-artifact@v4
         with:
-          name: release-assets
+          name: release-assets-windows-linux
           path: build/*.zip
 
 
@@ -152,7 +152,7 @@ jobs:
       - name: Upload macOS artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-assets
+          name: release-assets-macos
           path: build/${{ env.EXPORT_NAME }}-macOS.zip
   
   
@@ -165,7 +165,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: release-assets
           path: dist
 
       - name: Create GitHub Release


### PR DESCRIPTION
- 将 release-assets 重命名为 release-assets-windows-linux
- 将 macOS 构件名称重命名为 release-assets-macos
- 移除下载构件步骤以简化工作流