### PR TITLE
fix(workflow): 修复发布工作流中的文件路径匹配问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
           body: "Automated release for tag ${{ github.ref_name }}"
           draft: false
           prerelease: false
-          files: dist/*.zip
+          files: dist/**/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
       # 调试用途：列出已成功上传到 Release 的附件信息


### PR DESCRIPTION
- 修改了 GitHub Actions 工作流中附件文件的路径模式
- 将 files 配置从 dist/*.zip 更新为 dist/**/*.zip
- 确保所有子目录中的 zip 文件都能被正确上传到发布版本