### PR TITLE
fix(loot): 修复节点查找和物理对象池管理问题

### DIFF
--- a/scenes/loot/Loot.cs
+++ b/scenes/loot/Loot.cs
@@ -18,11 +18,33 @@ public partial class Loot : CharacterBody2D, IPoolableNode, IController
 	// 对象池引用
 	private ILootPoolSystem _pool = null!;
 
-	private SpaceShip SpaceShip => GetTree().Root.GetNode<SpaceShip>("Space/SpaceShip");
+	private SpaceShip SpaceShip
+	{
+		get
+		{
+			var ship = GetTree().Root.GetNodeOrNull<SpaceShip>("Space/SpaceShip");
+			if (ship == null)
+			{
+				GD.PushWarning("Loot: SpaceShip 节点未找到");
+			}
+			return ship!;
+		}
+	}
 	private AnimatedSprite2D AnimatedSprite2D => GetNode<AnimatedSprite2D>("%AnimatedSprite2D");
 	private CollisionShape2D CollisionShape => GetNode<CollisionShape2D>("%CollisionShape2D");
 
-	private Cargo Cargo => GetTree().Root.GetNode<Cargo>("Space/UI/Cargo");
+	private Cargo Cargo
+	{
+		get
+		{
+			var cargo = GetTree().Root.GetNodeOrNull<Cargo>("Space/UI/MarginContainer/HBoxContainer/Cargo");
+			if (cargo == null)
+			{
+				GD.PushWarning("Loot: Cargo 节点未找到");
+			}
+			return cargo!;
+		}
+	}
 
 	public override void _Ready()
 	{
@@ -32,6 +54,11 @@ public partial class Loot : CharacterBody2D, IPoolableNode, IController
 
 	public override void _PhysicsProcess(double delta)
 	{
+		if (SpaceShip == null || Cargo == null)
+		{
+			return; // 如果必要节点不存在，直接返回
+		}
+
 		if (IsCollected)
 		{
 			//应用速度，持续向飞船方向移动
@@ -77,7 +104,7 @@ public partial class Loot : CharacterBody2D, IPoolableNode, IController
 	}
 
 	/// <summary>
-	/// 从池中获取时调用
+	/// 从池中获取时调用	
 	/// </summary>
 	public void OnAcquire()
 	{

--- a/scripts/core/AbstractNodePoolSystem.cs
+++ b/scripts/core/AbstractNodePoolSystem.cs
@@ -97,6 +97,12 @@ public abstract class AbstractNodePoolSystem<TKey, TNode>
         node.Visible = true;
         node.SetProcess(true);
         node.SetPhysicsProcess(true);
+        
+        // 对于 RigidBody2D，需要恢复物理模拟
+        if (node is RigidBody2D rigidBody)
+        {
+            rigidBody.Freeze = false;
+        }
     }
 
     /// <summary>
@@ -108,6 +114,12 @@ public abstract class AbstractNodePoolSystem<TKey, TNode>
         node.Visible = false;
         node.SetProcess(false);
         node.SetPhysicsProcess(false);
+        
+        // 对于 RigidBody2D，需要停止物理模拟以避免性能损耗
+        if (node is RigidBody2D rigidBody)
+        {
+            rigidBody.Freeze = true;
+        }
     }
 
     /// <summary>

--- a/scripts/loot/LootPoolSystem.cs
+++ b/scripts/loot/LootPoolSystem.cs
@@ -28,6 +28,18 @@ public class SimpleNodePool<TNode> : AbstractSystem where TNode : Node2D, IPoola
         node.SetProcess(true);
         node.SetPhysicsProcess(true);
         node.Visible = true;
+        
+        // 对于 CharacterBody2D/RigidBody2D，恢复物理模拟
+        if (node is CharacterBody2D characterBody)
+        {
+            // CharacterBody2D 使用 MotionMode，没有 Freeze，但可以通过设置速度为0来停止
+            characterBody.Velocity = Vector2.Zero;
+        }
+        else if (node is RigidBody2D rigidBody)
+        {
+            rigidBody.Freeze = false;
+        }
+        
         node.OnAcquire();
         
         return node;
@@ -39,6 +51,18 @@ public class SimpleNodePool<TNode> : AbstractSystem where TNode : Node2D, IPoola
         node.SetProcess(false);
         node.SetPhysicsProcess(false);
         node.Visible = false;
+        
+        // 对于 CharacterBody2D/RigidBody2D，停止物理模拟
+        if (node is CharacterBody2D characterBody)
+        {
+            // CharacterBody2D 通过停止速度和禁用物理处理来停止
+            characterBody.Velocity = Vector2.Zero;
+        }
+        else if (node is RigidBody2D rigidBody)
+        {
+            rigidBody.Freeze = true;
+        }
+        
         node.GetParent()?.RemoveChild(node);
         
         Pool.Push(node);


### PR DESCRIPTION
- 修改 Loot 组件中 SpaceShip 和 Cargo 节点的获取方式，使用 GetNodeOrNull 避免空引用异常
- 添加节点未找到时的警告日志输出
- 在 PhysicsProcess 中检查必要节点是否存在，避免空引用导致的游戏崩溃
- 更新 Cargo 节点的路径地址到新的 UI 结构位置
- 在 SpaceRock 组件中添加动态计时器跟踪列表，防止内存泄漏
- 在对象释放时清理动态创建的计时器资源
- 优化对象池系统中的 RigidBody2D 物理状态管理，在获取和释放时正确设置 Freeze 状态
- 为 CharacterBody2D 对象添加速度重置逻辑，确保物理状态正确恢复和停止