### PR TITLE
docs(license): 添加许可证说明文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # CosmicMiningCompany
+## License
+
+### Source Code
+This project’s source code is licensed under the Apache License, Version 2.0.
+
+### Game Assets
+All game assets (including but not limited to art, audio, fonts, and text)
+are NOT covered by the Apache License 2.0.
+
+Unless otherwise stated, all assets are © the authors and may not be used
+without explicit permission.


### PR DESCRIPTION
- 添加了项目源代码的 Apache License 2.0 许可证声明
- 明确了游戏资源（包括艺术、音频、字体和文本）不适用 Apache 许可证
- 注明了游戏资源的所有权归属和使用权限限制
- 提供了关于许可证的详细分类说明
- close #86 