### PR TITLE
feat(main_menu): 添加主菜单背景着色器效果

### DIFF
--- a/scenes/main_menu/main_menu.gdshader
+++ b/scenes/main_menu/main_menu.gdshader
@@ -1,0 +1,44 @@
+shader_type canvas_item;
+
+uniform vec4 color1 : source_color = vec4(0.984, 0.961, 0.937, 1.0); // 最亮
+uniform vec4 color2 : source_color = vec4(0.949, 0.827, 0.671, 1.0);
+uniform vec4 color3 : source_color = vec4(0.776, 0.624, 0.647, 1.0);
+uniform vec4 color4 : source_color = vec4(0.545, 0.427, 0.612, 1.0);
+uniform vec4 color5 : source_color = vec4(0.286, 0.302, 0.494, 1.0); 
+uniform vec4 color6 : source_color = vec4(0.075, 0.078, 0.18, 1.0); // 最暗
+uniform sampler2D screen_texture : hint_screen_texture, repeat_disable, filter_nearest;
+void vertex() {
+    // Called for every vertex the material is visible on.
+}
+
+void fragment() {
+    // 获取屏幕纹理颜色
+    vec4 original_color = textureLod(screen_texture, SCREEN_UV, 0.0);
+
+    // 计算亮度（根据文档中的亮度公式）
+    float luminance = dot(original_color.rgb, vec3(0.2125, 0.7154, 0.0721));
+
+    // 根据亮度选择对应的颜色
+    vec4 selected_color;
+
+    if (luminance >= 0.95) {
+        selected_color = color1;
+    } else if (luminance >= 0.65) {
+        selected_color = color2;
+    } else if (luminance >= 0.5) {
+        selected_color = color3;
+    } else if (luminance >= 0.35) {
+        selected_color = color4;
+    } else if(luminance >= 0.2){
+        selected_color = color5;
+    }else {
+        selected_color = color6;
+    }
+
+     COLOR = selected_color;
+}
+
+//void light() {
+//    // Called for every pixel for every light affecting the CanvasItem.
+//    // Uncomment to replace the default light processing function with this one.
+//}

--- a/scenes/main_menu/main_menu.gdshader.uid
+++ b/scenes/main_menu/main_menu.gdshader.uid
@@ -1,0 +1,1 @@
+uid://yx1hnj3uanro

--- a/scenes/main_menu/main_menu.tscn
+++ b/scenes/main_menu/main_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=3 uid="uid://dgnuqqco6xbmw"]
+[gd_scene load_steps=13 format=3 uid="uid://dgnuqqco6xbmw"]
 
 [ext_resource type="Script" uid="uid://brpe1cvn7jnbp" path="res://scenes/main_menu/MainMenu.cs" id="1_o25w2"]
 [ext_resource type="Theme" uid="uid://cfadp5dxx3ld1" path="res://resources/theme.tres" id="2_cds3d"]
@@ -6,6 +6,7 @@
 [ext_resource type="Shader" uid="uid://clber8wcbyxn7" path="res://assets/art/bright_star_test.gdshader" id="3_3ovsr"]
 [ext_resource type="Texture2D" uid="uid://cyctgu4oqqats" path="res://assets/art/planet03.png" id="4_4xg86"]
 [ext_resource type="Shader" uid="uid://baqqpsotv4dfc" path="res://assets/art/pixel.gdshader" id="4_5seab"]
+[ext_resource type="Shader" uid="uid://yx1hnj3uanro" path="res://scenes/main_menu/main_menu.gdshader" id="4_thkx5"]
 [ext_resource type="Texture2D" uid="uid://b0ym1yy5pdtxy" path="res://assets/art/标题.png" id="6_3ovsr"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_4xg86"]
@@ -13,6 +14,15 @@ shader = ExtResource("2_wem23")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_thkx5"]
 shader = ExtResource("3_3ovsr")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_lqpn7"]
+shader = ExtResource("4_thkx5")
+shader_parameter/color1 = Color(0.984, 0.961, 0.937, 1)
+shader_parameter/color2 = Color(0.949, 0.827, 0.671, 1)
+shader_parameter/color3 = Color(0.776, 0.624, 0.647, 1)
+shader_parameter/color4 = Color(0.545, 0.427, 0.612, 1)
+shader_parameter/color5 = Color(0.286, 0.302, 0.494, 1)
+shader_parameter/color6 = Color(0.075, 0.078, 0.18, 1)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_x2yjq"]
 shader = ExtResource("4_5seab")
@@ -61,7 +71,17 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(1, 1, 1, 0)
 
+[node name="ColorRect" type="ColorRect" parent="."]
+material = SubResource("ShaderMaterial_lqpn7")
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
 [node name="pixel" type="ColorRect" parent="."]
+visible = false
 material = SubResource("ShaderMaterial_x2yjq")
 layout_mode = 1
 anchors_preset = 15

--- a/scenes/tests/test_VFX/background_test.tscn
+++ b/scenes/tests/test_VFX/background_test.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=29 format=3 uid="uid://d0cm2pfa3u3ss"]
+[gd_scene load_steps=31 format=3 uid="uid://d0cm2pfa3u3ss"]
 
 [ext_resource type="Shader" uid="uid://bo07iwf6vb2x4" path="res://assets/art/tiny_star_test.gdshader" id="1_gi24m"]
 [ext_resource type="Shader" uid="uid://clber8wcbyxn7" path="res://assets/art/bright_star_test.gdshader" id="2_hwurh"]
 [ext_resource type="Shader" uid="uid://baqqpsotv4dfc" path="res://assets/art/pixel.gdshader" id="3_mgvpm"]
 [ext_resource type="FontFile" uid="uid://cr2i4stnkh5fc" path="res://assets/fonts/VonwaonBitmap-16px.ttf" id="4_gb8ji"]
+[ext_resource type="Shader" uid="uid://yx1hnj3uanro" path="res://scenes/main_menu/main_menu.gdshader" id="4_mgvpm"]
 [ext_resource type="Texture2D" uid="uid://1xnk8rvurye" path="res://assets/art/oil-6-32x.png" id="5_mvhjx"]
 [ext_resource type="Shader" uid="uid://bsb0cwho76tw8" path="res://assets/art/line.gdshader" id="6_lmjjp"]
 [ext_resource type="Texture2D" uid="uid://cc0kyy84m3qcu" path="res://assets/art/宝石.png" id="7_s6ttp"]
@@ -29,6 +30,15 @@ shader = ExtResource("1_gi24m")
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_37kl0"]
 shader = ExtResource("2_hwurh")
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_gb8ji"]
+shader = ExtResource("4_mgvpm")
+shader_parameter/color1 = Color(0.984, 0.961, 0.937, 1)
+shader_parameter/color2 = Color(0.949, 0.827, 0.671, 1)
+shader_parameter/color3 = Color(0.776, 0.624, 0.647, 1)
+shader_parameter/color4 = Color(0.545, 0.427, 0.612, 1)
+shader_parameter/color5 = Color(0.286, 0.302, 0.494, 1)
+shader_parameter/color6 = Color(0.075, 0.078, 0.18, 1)
 
 [sub_resource type="Theme" id="Theme_yo6cv"]
 default_font = ExtResource("4_gb8ji")
@@ -100,6 +110,15 @@ polygon = PackedVector2Array(-10000, -10000, 10000, -10000, 10000, 10000, -10000
 [node name="bright_star" type="Polygon2D" parent="."]
 material = SubResource("ShaderMaterial_37kl0")
 polygon = PackedVector2Array(-10000, -10000, 10000, -10000, 10000, 10000, -10000, 10000)
+
+[node name="ColorRect" type="ColorRect" parent="bright_star"]
+material = SubResource("ShaderMaterial_gb8ji")
+custom_minimum_size = Vector2(20000, 20000)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="备忘" type="Label" parent="."]
 visible = false


### PR DESCRIPTION
新增了主菜单场景的背景着色器，包括新的ShaderMaterial资源和
ColorRect节点来实现背景视觉效果。

- 添加新的main_menu.gdshader资源引用
- 创建ShaderMaterial并配置颜色参数
- 在场景中添加ColorRect节点应用着色器效果
- 调整测试场景以包含相同的着色器资源用于验证