### PR TITLE
chore(ci): 更新构建脚本以优化打包过程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,14 @@ jobs:
           set -e
           godot --headless --export-release "Linux" build/linux/${{ env.EXPORT_NAME }}.x86_64 --quit
       - name: Package Windows
-        run: zip -r build/${{ env.EXPORT_NAME }}-windows.zip build/windows
+        run: |
+          cd build/windows
+          zip -r ../${{ env.EXPORT_NAME }}-windows.zip .
+      
       - name: Package Linux
-        run: zip -r build/${{ env.EXPORT_NAME }}-linux.zip build/linux
+        run: |
+          cd build/linux
+          zip -r ../${{ env.EXPORT_NAME }}-linux.zip .
       - uses: actions/upload-artifact@v4
         with:
           name: release-assets-windows-linux


### PR DESCRIPTION
- 修改 Windows 打包命令，切换到构建目录进行压缩
- 修改 Linux 打包命令，切换到构建目录进行压缩
- 使用相对路径避免嵌套目录结构
- 保持原有的上传工件配置不变